### PR TITLE
create_service_for_parsing_patient_data (Generate Diabetes Assessment)

### DIFF
--- a/src/main/java/com/abernathy/patientassessment/domain/TriggerCount.java
+++ b/src/main/java/com/abernathy/patientassessment/domain/TriggerCount.java
@@ -1,0 +1,62 @@
+package com.abernathy.patientassessment.domain;
+
+public class TriggerCount {
+
+    private boolean hemoglobin;
+    private boolean microalbumin;
+    private boolean bodyHeight;
+    private boolean bodyWeight;
+    private boolean smoker;
+    private boolean abnormal;
+    private boolean cholesterol;
+    private boolean dizziness;
+    private boolean relapse;
+    private boolean reaction;
+    private boolean antibodies;
+
+    public void addHemoglobin() {
+        hemoglobin = true;
+    }
+    public void addMicroalbumin() {
+        microalbumin = true;
+    }
+    public void addBodyHeight() {
+        bodyHeight = true;
+    }
+    public void addBodyWeight() {
+        bodyWeight = true;
+    }
+    public void addSmoker() {
+        smoker = true;
+    }
+    public void addAbnormal() {
+        abnormal = true;
+    }
+    public void addCholesterol() {
+        cholesterol = true;
+    }
+    public void addDizziness() {
+        dizziness = true;
+    }
+    public void addRelapse() {
+        relapse = true;
+    }
+    public void addReaction() {
+        reaction = true;
+    }
+    public void addAntibodies() {
+        antibodies = true;
+    }
+
+    public int getTriggerCount() {
+        int count = 0;
+        boolean[] triggers = {hemoglobin,microalbumin,bodyHeight,bodyWeight,smoker,
+        abnormal,cholesterol,dizziness,relapse,reaction,antibodies};
+        for (boolean trigger : triggers) {
+            if (trigger) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/com/abernathy/patientassessment/exceptions/NoNotesFoundException.java
+++ b/src/main/java/com/abernathy/patientassessment/exceptions/NoNotesFoundException.java
@@ -1,0 +1,15 @@
+package com.abernathy.patientassessment.exceptions;
+
+public class NoNotesFoundException extends Exception{
+
+    private int patId;
+
+    public NoNotesFoundException(int patId) {
+        this.patId = patId;
+    }
+
+    public int getPatId() {
+        return patId;
+    }
+
+}

--- a/src/main/java/com/abernathy/patientassessment/exceptions/PatientNotFoundException.java
+++ b/src/main/java/com/abernathy/patientassessment/exceptions/PatientNotFoundException.java
@@ -1,0 +1,14 @@
+package com.abernathy.patientassessment.exceptions;
+
+public class PatientNotFoundException extends Exception{
+
+    private int patId;
+
+    public PatientNotFoundException(int patId) {
+        this.patId = patId;
+    }
+
+    public int getPatId() {
+        return patId;
+    }
+}

--- a/src/main/java/com/abernathy/patientassessment/service/PatientAssessmentService.java
+++ b/src/main/java/com/abernathy/patientassessment/service/PatientAssessmentService.java
@@ -1,0 +1,88 @@
+package com.abernathy.patientassessment.service;
+
+import com.abernathy.patientassessment.domain.PatientAssessment;
+import com.abernathy.patientassessment.domain.PatientNote;
+import com.abernathy.patientassessment.domain.TriggerCount;
+import com.abernathy.patientassessment.exceptions.NoNotesFoundException;
+import com.abernathy.patientassessment.exceptions.PatientNotFoundException;
+import com.abernathy.patientassessment.remote.HistoryRemote;
+import com.abernathy.patientassessment.remote.PatientRemote;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class PatientAssessmentService {
+
+    private final HistoryRemote historyRemote;
+    private final PatientRemote patientRemote;
+
+    private Logger logger = LoggerFactory.getLogger(PatientAssessmentService.class);
+
+    public PatientAssessmentService(HistoryRemote historyRemote, PatientRemote patientRemote){
+        this.historyRemote = historyRemote;
+        this.patientRemote = patientRemote;
+    }
+
+    public PatientAssessment assessPatientRisk(int patId) throws PatientNotFoundException, NoNotesFoundException {
+        //Create PatientAssessment object with Patient and their PatientNotes
+        PatientAssessment patientAssessment = new PatientAssessment(patientRemote.getPatientById(patId),
+                historyRemote.getHistoryForPatient(patId));
+        //If we could not find a patient, or they have no notes, let caller know why we cannot generate an assessment
+        if (patientAssessment.getPatient()==null) {
+            throw new PatientNotFoundException(patId);
+        }
+        if (patientAssessment.getNotes().size()==0) {
+            throw new NoNotesFoundException(patId);
+        }
+
+        // Parse notes & calculate risk
+        int triggerCount = countTriggerTerms(patientAssessment.getNotes());
+
+
+        return null;
+    }
+
+    private int countTriggerTerms(List<PatientNote> notes) {
+        TriggerCount triggerCount = new TriggerCount();
+
+        for (PatientNote patientNote : notes) {
+            String note = patientNote.getNote().toLowerCase();
+            if (note.contains("hemoglobin a1c")){
+                triggerCount.addHemoglobin();
+            }
+            if (note.contains("microalbumin")){
+                triggerCount.addMicroalbumin();
+            }
+            if (note.contains("body height")){
+                triggerCount.addBodyHeight();
+            }
+            if (note.contains("body weight")){
+                triggerCount.addBodyWeight();
+            }
+            if (note.contains("smoker")){
+                triggerCount.addSmoker();
+            }
+            if (note.contains("abnormal")){
+                triggerCount.addAbnormal();
+            }
+            if (note.contains("cholesterol")){
+                triggerCount.addCholesterol();
+            }
+            if (note.contains("dizziness")){
+                triggerCount.addDizziness();
+            }
+            if (note.contains("relapse")){
+                triggerCount.addRelapse();
+            }
+            if (note.contains("reaction")){
+                triggerCount.addReaction();
+            }
+            if (note.contains("antibodies")){
+                triggerCount.addAntibodies();
+            }
+        }
+        return triggerCount.getTriggerCount();
+    }
+
+}


### PR DESCRIPTION
- added PatientAssessmentService for processing patient data and generating assessment
- added Exceptions to throw if requested patient doenst exist or has no notes
- added TriggerCount class to hold found trigger terms for processing
- added method to PatientAssessmentService to begin begin process and parse notes to count terms

Currently service can query other microservices to get patient & their notes, will throw an error if either of these is unsuccessful, and will parse through all the notes to check off which trigger terms are present.

https://trello.com/c/cedtNn3j/7-generate-diabetes-assessment